### PR TITLE
Proposed change to possibly enable PHP 7 support.

### DIFF
--- a/src/Apostle/PHPUnit/TestCase.php
+++ b/src/Apostle/PHPUnit/TestCase.php
@@ -4,7 +4,7 @@ namespace Apostle\PHPUnit;
 use Apostle\PHPUnit\Assert\Date;
 use Apostle\PHPUnit\Assert\Basic;
 use Apostle\PHPUnit\Assert\Number;
-use Apostle\PHPUnit\Assert\String;
+use Apostle\PHPUnit\Assert\String as TextString;
 use Apostle\PHPUnit\Assert\Finance;
 use Apostle\PHPUnit\Assert\Collection;
 
@@ -18,7 +18,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     use Date;
     use Basic;
     use Number;
-    use String;
+    use TextString;
     use Finance;
     use Collection;
 }


### PR DESCRIPTION
This may be a fix to "PHP Fatal error:  Cannot use Apostle\PHPUnit\Assert\String as String because 'String' is a special class name" and to close #1 
